### PR TITLE
Add RichTextEditor with Tiptap

### DIFF
--- a/app/api/pages/[slug]/route.ts
+++ b/app/api/pages/[slug]/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const DATA_DIR = path.join(process.cwd(), 'data', 'pages');
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { slug: string } }
+) {
+  const filePath = path.join(DATA_DIR, `${params.slug}.json`);
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return NextResponse.json(JSON.parse(data));
+  } catch (e) {
+    return NextResponse.json({ content: '' });
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { slug: string } }
+) {
+  const { content } = await request.json();
+  const filePath = path.join(DATA_DIR, `${params.slug}.json`);
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify({ content }), 'utf8');
+  return NextResponse.json({ success: true });
+}

--- a/app/pages/[slug]/page.tsx
+++ b/app/pages/[slug]/page.tsx
@@ -1,0 +1,11 @@
+import dynamic from "next/dynamic";
+
+const RichTextEditor = dynamic(() => import("@/components/editor/RichTextEditor"), { ssr: false });
+
+export default function Page({ params }: { params: { slug: string } }) {
+  return (
+    <div className="max-w-2xl mx-auto py-8">
+      <RichTextEditor slug={params.slug} />
+    </div>
+  );
+}

--- a/components/editor/RichTextEditor.tsx
+++ b/components/editor/RichTextEditor.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect } from "react";
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+
+export interface RichTextEditorProps {
+  slug: string;
+}
+
+export default function RichTextEditor({ slug }: RichTextEditorProps) {
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content: "",
+  });
+
+  useEffect(() => {
+    if (!editor) return;
+    fetch(`/api/pages/${slug}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.content) editor.commands.setContent(data.content);
+      });
+  }, [editor, slug]);
+
+  const saveContent = async () => {
+    if (!editor) return;
+    const content = editor.getHTML();
+    await fetch(`/api/pages/${slug}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <EditorContent editor={editor} className="border p-4 rounded-md" />
+      <button onClick={saveContent} className="px-3 py-1 bg-blue-600 text-white rounded-md">
+        Salvar
+      </button>
+    </div>
+  );
+}

--- a/data/pages/sample.json
+++ b/data/pages/sample.json
@@ -1,0 +1,1 @@
+{"content":"<p>Olá Mundo</p>"}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "next-themes": "0.4.6",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "source-map-js": "^1.2.1"
+    "source-map-js": "^1.2.1",
+    "@tiptap/react": "^2.2.3",
+    "@tiptap/starter-kit": "^2.0.3"
   },
   "devDependencies": {
     "@types/node": "22.15.3",


### PR DESCRIPTION
## Summary
- install `@tiptap/react` and `@tiptap/starter-kit`
- add API route `/api/pages/[slug]` for saving and loading page content
- create `RichTextEditor` component using Tiptap
- expose editor page under `/pages/[slug]`
- include sample page content

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f2346aec8330a750803e783d62a1