### PR TITLE
Add theme switcher

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Metadata, Viewport } from "next";
 import clsx from "clsx";
 
 import { Providers } from "./providers";
+import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 
 import { siteConfig } from "@/config/site";
 import { fontSans } from "@/config/fonts";
@@ -39,7 +40,10 @@ export default function RootLayout({
           fontSans.variable,
         )}
       >
-        <Providers themeProps={{ attribute: "class", defaultTheme: "dark" }}>
+        <Providers themeProps={{ attribute: "class", defaultTheme: "system" }}>
+          <div className="fixed top-6 right-6 z-50">
+            <ThemeSwitcher />
+          </div>
           {children}
         </Providers>
       </body>

--- a/components/ThemeSwitcher.tsx
+++ b/components/ThemeSwitcher.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Button } from "@heroui/button";
+import { SunFilledIcon, MoonFilledIcon } from "./icons";
+
+export const ThemeSwitcher = () => {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  const isDark = theme === "dark";
+
+  return (
+    <Button
+      size="lg"
+      className="font-mono font-bold backdrop-blur-lg bg-gray-500/20 border border-gray-500/50 text-gray-300 hover:bg-gray-500/30"
+      onPress={() => setTheme(isDark ? "light" : "dark")}
+    >
+      {isDark ? <SunFilledIcon size={20} /> : <MoonFilledIcon size={20} />}
+    </Button>
+  );
+};


### PR DESCRIPTION
## Summary
- respect saved theme when rendering Providers
- add `ThemeSwitcher` component using `next-themes`
- place ThemeSwitcher in the layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840f20cadec8330844ef2e1cdc4c1f7